### PR TITLE
feat: create first version of workload dashboard

### DIFF
--- a/scripts/otel-collector-daemonset.values.yaml
+++ b/scripts/otel-collector-daemonset.values.yaml
@@ -87,7 +87,6 @@ config:
     
     pipelines:
       metrics:
-
         receivers: [otlp, hostmetrics]
         processors: [
           resourcedetection,
@@ -98,7 +97,6 @@ config:
           batch,
         ]
         exporters: [otlphttp/metrics, prometheus]
-
 
 ports:
   prometheus:


### PR DESCRIPTION
I couldn't get the metrics for CPU limit and capacity to work, so I only have usage. I was able to add them for memory for now. 

I put two options for CPU usage. One by rate and one is just usage. From what I read, they should be the same metric, but it doesn't look that way... I left both in for now. I'll need to do some more digging to figure out which metric provides more accurate data. 


<img width="1596" height="618" alt="Screenshot 2025-11-21 at 12 43 20" src="https://github.com/user-attachments/assets/bac1e605-2ad4-4a46-b581-9700d9e3dca3" />

<img width="1249" height="317" alt="Screenshot 2025-11-21 at 12 49 14" src="https://github.com/user-attachments/assets/3ae2cd91-56e0-4817-925a-4089a3b8abb8" />
<img width="1243" height="262" alt="Screenshot 2025-11-21 at 12 49 24" src="https://github.com/user-attachments/assets/e67ed44b-d2a1-4a3b-8ff8-c72bd47e0d86" />
<img width="1256" height="267" alt="Screenshot 2025-11-21 at 12 49 32" src="https://github.com/user-attachments/assets/9955cc52-ca77-4c26-a60c-5bc6579fbac0" />
