### PR TITLE
Add K8s instrumentation based on the OTel Kube Stack helm chart

### DIFF
--- a/scripts/lgtm-otel-kube-stack.sh
+++ b/scripts/lgtm-otel-kube-stack.sh
@@ -20,7 +20,7 @@ helm repo update
 
 # Deploy the OTel Kube Stack
 helm upgrade --install opentelemetry-stack opentelemetry/opentelemetry-kube-stack \
-    -f "$PWD"/otel-kube-stack-values.yaml \
+    -f otel-kube-stack-values.yaml \
     --kube-context k3d-kubernetes-mixin-otel \
     --namespace default \
     --wait \

--- a/scripts/otel-kube-stack-values.yaml
+++ b/scripts/otel-kube-stack-values.yaml
@@ -4,7 +4,7 @@ clusterName: my-otel-stack
 collectors:
   daemon:
     enabled: true
-    # disable scrapping using daemon_scrape_configs.yaml as it assumes the Prometheus Node Exporter and CAdvisor are setup
+    # disable scraping using daemon_scrape_configs.yaml as it assumes the Prometheus Node Exporter and CAdvisor are setup
     # https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack#scrape_configs_file-details
     scrape_configs_file: ""
     presets:
@@ -31,7 +31,7 @@ collectors:
           logs:
             exporters:
               - otlphttp
-    securityContext: # Run daemon collector as root for metrics & logs scrapping
+    securityContext: # Run daemon collector as root for metrics & logs scraping
       runAsUser: 0
       runAsGroup: 0
 instrumentation:


### PR DESCRIPTION
Add K8s instrumentation based on the OTel Kube Stack helm chart.
It could replace the otel-collector helm chart as it's a kind of superset that also solves the instrumentation of the workloads through the OpenTelemetry Operator.