### PR TITLE
chore(security): harden supply chain and GHA security  

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
       groupName: "github actions",
     },
     {
-      matchManagers: ["dockerfile", "docker-compose"],
+      matchManagers: ["dockerfile", "docker-compose", "shell"],
       groupName: "docker",
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
+  minimumReleaseAge: "3 days",
   schedule: ["on Monday"],
   packageRules: [
     {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -7,7 +7,7 @@
           "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git"
         }
       },
-      "version": "master"
+      "version": "ca6936ebb8653337c9d8e024ed781113a8b007d6"
     }
   ],
   "legacyImports": true

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -48,8 +48,8 @@
           "subdir": ""
         }
       },
-      "version": "acd544dbd02ebce1e000abe006df6d2e4ac1438e",
-      "sum": "aRBESvZpnMG7iDNIR0CP+8yuvZyF4rQn8FLlXpBxGW8="
+      "version": "ca6936ebb8653337c9d8e024ed781113a8b007d6",
+      "sum": "W3T+8vMVawd1vDvuTQvFIv+NbW5jF5+9cj/EmZN4q7k="
     }
   ],
   "legacyImports": false

--- a/scripts/kwok-stats-proxy/Dockerfile
+++ b/scripts/kwok-stats-proxy/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 WORKDIR /app
-COPY go.mod go.sum* ./
-RUN go mod download || true
+COPY go.mod go.sum ./
+RUN go mod download
+RUN go mod verify
 COPY . .
-RUN go mod tidy
 RUN CGO_ENABLED=0 go build -o kwok-stats-proxy .
 
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11

--- a/scripts/run-kwok-beyla.sh
+++ b/scripts/run-kwok-beyla.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+# renovate: datasource=docker depName=grafana/beyla
+BEYLA_IMAGE="grafana/beyla:3.15.0@sha256:8ff0dcb4aa31fab39ba0b40715d0c0441d4522b43fb7886768ec280cc401dd69"
+
 # Stop gracefully first, then force remove (avoids zombie with --pid=host)
 if docker ps -a --format '{{.Names}}' | grep -q '^kwok-beyla$'; then
   echo "[beyla] Stopping kwok-beyla container..."
@@ -32,7 +35,7 @@ docker run -d \
   -e BEYLA_TRACES_EXPORTER=otlp \
   -e OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
   -e OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" \
-  grafana/beyla:3.15.0
+  "${BEYLA_IMAGE}"
 
 echo "[beyla] Beyla tracing enabled - query traces will appear in Grafana Tempo"
 

--- a/scripts/run-kwok-beyla.sh
+++ b/scripts/run-kwok-beyla.sh
@@ -32,7 +32,7 @@ docker run -d \
   -e BEYLA_TRACES_EXPORTER=otlp \
   -e OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
   -e OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" \
-  grafana/beyla:latest
+  grafana/beyla:3.15.0
 
 echo "[beyla] Beyla tracing enabled - query traces will appear in Grafana Tempo"
 

--- a/scripts/run-kwok-env.sh
+++ b/scripts/run-kwok-env.sh
@@ -10,6 +10,11 @@ OTEL_CONFIG="${SCRIPT_DIR}/kwok-config/kwok-otel-collector.yaml"
 KUBECONFIG_TEMPLATE="${SCRIPT_DIR}/kwok-config/otel-kwokconfig.yaml"
 KUBECONFIG_OUT="/tmp/kwok-kubeconfig"
 
+# renovate: datasource=docker depName=grafana/otel-lgtm
+LGTM_IMAGE="grafana/otel-lgtm:0.28.0@sha256:74bd8c8be4344dd51fb76f2030522e5c886bc585d4e965234a68b49960c98c5e"
+# renovate: datasource=docker depName=otel/opentelemetry-collector-contrib
+OTELCOL_IMAGE="otel/opentelemetry-collector-contrib:0.153.0@sha256:2e9646ff882e043b5e046dbad14cf76b59f6cc108053e1e3a863b14d532b43ec"
+
 # Configurable node and pod counts (defaults: 1 node, 0 batch pods for parity with dev)
 NODE_COUNT="${NODE_COUNT:-1}"
 POD_COUNT="${POD_COUNT:-0}"
@@ -87,7 +92,7 @@ else
     -p 9090:9090 \
     -v "${SCRIPT_DIR}/provisioning/dashboards/dashboards.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/dashboards.yaml" \
     -v "${SCRIPT_DIR}/../dashboards_out:/kubernetes-mixin-otel/dashboards_out" \
-    grafana/otel-lgtm:0.28.0
+    "${LGTM_IMAGE}"
 fi
 
 # 6. Build and start kwok-stats-proxy (provides /stats/summary for kubeletstatsreceiver)
@@ -113,7 +118,7 @@ docker run -d \
   -e STATS_PROXY_ENDPOINT="http://host.docker.internal:10250" \
   -p 8889:8889 \
   -v "${OTEL_CONFIG}:/etc/otelcol/config.yaml" \
-  otel/opentelemetry-collector-contrib:0.153.0 \
+  "${OTELCOL_IMAGE}" \
   --config /etc/otelcol/config.yaml
 
 # 8. Start hostmetrics faker (single lightweight container replaces N replicator containers).

--- a/scripts/run-kwok-env.sh
+++ b/scripts/run-kwok-env.sh
@@ -87,7 +87,7 @@ else
     -p 9090:9090 \
     -v "${SCRIPT_DIR}/provisioning/dashboards/dashboards.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/dashboards.yaml" \
     -v "${SCRIPT_DIR}/../dashboards_out:/kubernetes-mixin-otel/dashboards_out" \
-    grafana/otel-lgtm:latest
+    grafana/otel-lgtm:0.28.0
 fi
 
 # 6. Build and start kwok-stats-proxy (provides /stats/summary for kubeletstatsreceiver)
@@ -113,7 +113,7 @@ docker run -d \
   -e STATS_PROXY_ENDPOINT="http://host.docker.internal:10250" \
   -p 8889:8889 \
   -v "${OTEL_CONFIG}:/etc/otelcol/config.yaml" \
-  otel/opentelemetry-collector-contrib:latest \
+  otel/opentelemetry-collector-contrib:0.153.0 \
   --config /etc/otelcol/config.yaml
 
 # 8. Start hostmetrics faker (single lightweight container replaces N replicator containers).


### PR DESCRIPTION
This PR:
  - Pin `kwok-stats-proxy` Dockerfile: drop `|| true`, replace `go mod tidy` with `go mod verify` to validate without mutating
  - Replace `:latest` docker tags with pinned versions in dev scripts                                                                
  - Add `permissions: contents: read` to CI workflow to explicitly set read-only to prevent compromised workflow step that may push code, create releases, or modify the repo.                                                                                
  - Pin `jsonnetfile.json` kubernetes-mixin to specific commit (was `master`)                                                        
  - Add `minimumReleaseAge: "3 days"` to Renovate (72h supply chain cooldown)                                                        
                                                                                                                                     
  ## Test plan                                                                                                                     
  - [x] `docker build scripts/kwok-stats-proxy/` succeeds                                                                            
  - [x] CI passes  