### PR TITLE
dashboards: port persistent volumes dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,4 +198,5 @@ test-jsonnet: $(JSONNET_BIN) $(JSONNET_VENDOR)
 	@echo "Running jsonnet query tests..."
 	@$(JSONNET_BIN) -J vendor tests/pod_queries_test.libsonnet
 	@$(JSONNET_BIN) -J vendor tests/namespace_queries_test.libsonnet
+	@$(JSONNET_BIN) -J vendor tests/persistentvolumesusage_queries_test.libsonnet
 	@echo "All tests passed!"

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -1,1 +1,2 @@
+(import 'persistentvolumesusage.libsonnet') +
 (import 'resources.libsonnet')

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -1,0 +1,36 @@
+local config = import '../config.libsonnet';
+
+// Import kubernetes-mixin template directly from vendor
+// It will use local queries from dashboards/queries/persistentvolumesusage.libsonnet
+local localQueries = import './queries/persistentvolumesusage.libsonnet';
+local localVariables = import './variables/persistentvolumesusage.libsonnet';
+local k8sMixinPersistentVolume = import 'github.com/kubernetes-monitoring/kubernetes-mixin/dashboards/persistentvolumesusage.libsonnet';
+
+// Override queries and variables to use local ones instead of default
+local merged = {
+  _config: config._config,
+  _queries: {
+    persistentVolume: localQueries,
+  },
+  _variables: {
+    persistentVolume: function(config) localVariables.persistentVolume(config),
+  },
+} + k8sMixinPersistentVolume;
+
+{
+  _config: config._config,
+  grafanaDashboards+:: {
+    'persistentvolumesusage.json': merged.grafanaDashboards['persistentvolumesusage.json']
+                                   {
+      panels: [
+        panel {
+          datasource: {
+            type: 'datasource',
+            uid: '${datasource}',
+          },
+        }
+        for panel in merged.grafanaDashboards['persistentvolumesusage.json'].panels
+      ],
+    },
+  },
+}

--- a/dashboards/queries/persistentvolumesusage.libsonnet
+++ b/dashboards/queries/persistentvolumesusage.libsonnet
@@ -1,0 +1,42 @@
+// queries path must match the path in the kubernetes-mixin template
+//
+// Metrics come from the kubeletstats receiver `volume` metric group:
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md
+//
+// Naming notes:
+// - `k8s.volume.available` / `k8s.volume.capacity` (unit: By) are exported to
+//   Prometheus as `k8s_volume_available_bytes` / `k8s_volume_capacity_bytes`.
+// - `k8s.volume.inodes` / `k8s.volume.inodes.used` (unit: 1) gain a `_ratio`
+//   suffix from the Prometheus OTLP translation of dimensionless gauges, so
+//   they are queried as `k8s_volume_inodes_ratio` / `k8s_volume_inodes_used_ratio`
+//   despite being absolute inode counts.
+//
+// The `k8s_persistentvolumeclaim_name` label requires the kubeletstats
+// receiver option `extra_metadata_labels: [k8s.volume.type]`.
+//
+// `max()` collapses per-pod/per-node label noise (job, instance,
+// k8s_pod_name, ...) and deduplicates repeated reports of the same PVC,
+// mirroring the `sum without(...) (topk(1, ...))` pattern used upstream.
+{
+  local filters = 'k8s_cluster_name="$cluster", k8s_namespace_name="$namespace", k8s_persistentvolumeclaim_name="$volume"',
+
+  // Volume Space Usage
+  volumeSpaceUsageUsed(config)::
+    'max(k8s_volume_capacity_bytes{%(filters)s}) - max(k8s_volume_available_bytes{%(filters)s})' % { filters: filters },
+
+  volumeSpaceUsageFree(config)::
+    'max(k8s_volume_available_bytes{%(filters)s})' % { filters: filters },
+
+  volumeSpaceUsagePercent(config)::
+    '(max(k8s_volume_capacity_bytes{%(filters)s}) - max(k8s_volume_available_bytes{%(filters)s})) / max(k8s_volume_capacity_bytes{%(filters)s}) * 100' % { filters: filters },
+
+  // Volume inodes Usage
+  volumeInodesUsageUsed(config)::
+    'max(k8s_volume_inodes_used_ratio{%(filters)s})' % { filters: filters },
+
+  volumeInodesUsageFree(config)::
+    'max(k8s_volume_inodes_ratio{%(filters)s}) - max(k8s_volume_inodes_used_ratio{%(filters)s})' % { filters: filters },
+
+  volumeInodesUsagePercent(config)::
+    'max(k8s_volume_inodes_used_ratio{%(filters)s}) / max(k8s_volume_inodes_ratio{%(filters)s}) * 100' % { filters: filters },
+}

--- a/dashboards/variables/persistentvolumesusage.libsonnet
+++ b/dashboards/variables/persistentvolumesusage.libsonnet
@@ -1,0 +1,57 @@
+// variables path must match the path in the kubernetes-mixin template
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+local commonVariables = import '../resources/variables/common.libsonnet';
+
+// Single-select (not multi) mirrors the upstream kubernetes-mixin dashboard:
+// the space/inodes gauges compute ratios for one PersistentVolumeClaim at a
+// time and would be meaningless across several volumes.
+//
+// `k8s_persistentvolumeclaim_name!=""` restricts the variables to PVC-backed
+// volumes; the kubeletstats `volume` metric group also reports configMap,
+// secret and emptyDir volumes which have no PVC name.
+{
+  persistentVolume(config):: {
+    datasource: commonVariables.datasource(config),
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'k8s_cluster_name',
+        'k8s_volume_capacity_bytes{k8s_persistentvolumeclaim_name!=""}',
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace:
+      var.query.new('namespace')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'k8s_namespace_name',
+        'k8s_volume_capacity_bytes{k8s_cluster_name="$cluster", k8s_persistentvolumeclaim_name!=""}',
+      )
+      + var.query.generalOptions.withLabel('Namespace')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    volume:
+      var.query.new('volume')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'k8s_persistentvolumeclaim_name',
+        'k8s_volume_capacity_bytes{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace"}',
+      )
+      + var.query.generalOptions.withLabel('PersistentVolumeClaim')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/variables/persistentvolumesusage.libsonnet
+++ b/dashboards/variables/persistentvolumesusage.libsonnet
@@ -47,7 +47,7 @@ local commonVariables = import '../resources/variables/common.libsonnet';
       + var.query.withDatasourceFromVariable(self.datasource)
       + var.query.queryTypes.withLabelValues(
         'k8s_persistentvolumeclaim_name',
-        'k8s_volume_capacity_bytes{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace"}',
+        'k8s_volume_capacity_bytes{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace", k8s_persistentvolumeclaim_name!=""}',
       )
       + var.query.generalOptions.withLabel('PersistentVolumeClaim')
       + var.query.refresh.onTime()

--- a/docs/otel-mapping.md
+++ b/docs/otel-mapping.md
@@ -161,6 +161,18 @@ cAdvisor-specific and require the cAdvisor endpoint.
 | `kubelet_volume_stats_inodes_free` | `k8s.volume.inodes.free` | `k8s.pod.volume.inode.free` | Name mismatch |
 | `kubelet_volume_stats_inodes_used` | `k8s.volume.inodes.used` | `k8s.pod.volume.inode.used` | Name mismatch |
 
+Volume metric collection notes:
+
+- The kubeletstats `volume` metric group is **not collected by default**;
+  it must be enabled via `metric_groups: [container, pod, node, volume]`.
+- The `k8s.persistentvolumeclaim.name` resource attribute (needed to filter
+  volumes by PVC) requires `extra_metadata_labels: [k8s.volume.type]` and
+  `get` on `nodes/proxy` RBAC (kubelet `/pods` endpoint).
+- The inode metrics have unit `1`, so the Prometheus OTLP translation
+  appends a `_ratio` suffix to these dimensionless gauges: query them as
+  `k8s_volume_inodes_ratio`, `k8s_volume_inodes_used_ratio` and
+  `k8s_volume_inodes_free_ratio` even though they are absolute counts.
+
 ### PodDisruptionBudgets / ResourceQuotas
 
 | Prometheus metric | OTel receiver metric | OTel semconv metric | Notes |

--- a/scripts/lgtm.sh
+++ b/scripts/lgtm.sh
@@ -12,6 +12,11 @@ kubectl --context k3d-kubernetes-mixin-otel wait --for=condition=Ready nodes --a
 # Deploy the LGTM stack
 kubectl --context k3d-kubernetes-mixin-otel apply -f lgtm.yaml
 
+# Create the backing directory for the static local PersistentVolume, then
+# deploy a PVC-backed workload so the Persistent Volumes dashboard has data.
+docker exec k3d-kubernetes-mixin-otel-server-0 mkdir -p /var/lib/kubernetes-mixin-otel/pv-writer
+kubectl --context k3d-kubernetes-mixin-otel apply -f pv-workload.yaml
+
 # Disabled until Git Sync supports local rendering without requiring a public instance.
 # kubectl --context k3d-kubernetes-mixin-otel apply -f grafana-image-renderer.yaml
 

--- a/scripts/lgtm.sh
+++ b/scripts/lgtm.sh
@@ -12,9 +12,15 @@ kubectl --context k3d-kubernetes-mixin-otel wait --for=condition=Ready nodes --a
 # Deploy the LGTM stack
 kubectl --context k3d-kubernetes-mixin-otel apply -f lgtm.yaml
 
-# Create the backing directory for the static local PersistentVolume, then
+# Back the static local PersistentVolume with a small tmpfs mount, then
 # deploy a PVC-backed workload so the Persistent Volumes dashboard has data.
-docker exec k3d-kubernetes-mixin-otel-server-0 mkdir -p /var/lib/kubernetes-mixin-otel/pv-writer
+# A plain directory would sit on the node's overlayfs root: capacity would
+# report the whole node disk, and inode stats would be zero when the Docker
+# backing filesystem is btrfs (statfs f_files=0). tmpfs reports a real 1Gi
+# capacity and real inode counts; nr_inodes is kept small so the writer's
+# ~20 files register as visible inode utilisation on the dashboard.
+docker exec k3d-kubernetes-mixin-otel-server-0 sh -c \
+    'mkdir -p /var/lib/kubernetes-mixin-otel/pv-writer && mount -t tmpfs -o size=1g,nr_inodes=512 tmpfs /var/lib/kubernetes-mixin-otel/pv-writer'
 kubectl --context k3d-kubernetes-mixin-otel apply -f pv-workload.yaml
 
 # Disabled until Git Sync supports local rendering without requiring a public instance.

--- a/scripts/otel-collector-daemonset.values.yaml
+++ b/scripts/otel-collector-daemonset.values.yaml
@@ -21,6 +21,15 @@ config:
           endpoint: 0.0.0.0:4317
         http:
           endpoint: 0.0.0.0:4318
+    kubeletstats:
+      # The `volume` group is not collected by default; it provides the
+      # k8s.volume.* metrics used by the Persistent Volumes dashboard.
+      metric_groups: [container, pod, node, volume]
+      # Emits k8s.volume.type and, for PVC-backed volumes, the
+      # k8s.persistentvolumeclaim.name resource attribute.
+      # Requires `get` on nodes/proxy (see clusterRole below).
+      extra_metadata_labels:
+        - k8s.volume.type
     hostmetrics:
       scrapers:
         cpu:
@@ -44,6 +53,15 @@ config:
           statements:
             - set(attributes["k8s.node.name"], resource.attributes["k8s.node.name"]) where resource.attributes["k8s.node.name"] != nil
             - set(attributes["host.name"], resource.attributes["host.name"]) where resource.attributes["host.name"] != nil
+
+    transform/copy_volume_attributes:
+    # workaround: volume resource attributes are not promoted by the Prometheus OTLP endpoint
+      metric_statements:
+        - context: datapoint
+          statements:
+            - set(attributes["k8s.volume.name"], resource.attributes["k8s.volume.name"]) where resource.attributes["k8s.volume.name"] != nil
+            - set(attributes["k8s.volume.type"], resource.attributes["k8s.volume.type"]) where resource.attributes["k8s.volume.type"] != nil
+            - set(attributes["k8s.persistentvolumeclaim.name"], resource.attributes["k8s.persistentvolumeclaim.name"]) where resource.attributes["k8s.persistentvolumeclaim.name"] != nil
 
     k8sattributes:
       extract:
@@ -94,6 +112,7 @@ config:
           resource/k8sclustername,
           resource/hostname,
           transform/copy_node_name,
+          transform/copy_volume_attributes,
           batch,
         ]
         exporters: [otlphttp/metrics, prometheus]
@@ -104,3 +123,11 @@ ports:
     containerPort: 8889
     servicePort: 8889
     protocol: TCP
+
+clusterRole:
+  rules:
+    # The kubelet /pods endpoint (used by kubeletstats extra_metadata_labels
+    # to resolve PVC references) authorizes as `get` on nodes/proxy.
+    - apiGroups: ['']
+      resources: ['nodes/proxy']
+      verbs: ['get']

--- a/scripts/pv-workload.yaml
+++ b/scripts/pv-workload.yaml
@@ -6,8 +6,9 @@
 # has no metrics provider). `local` volumes report stats via statfs, which
 # the kubeletstats receiver picks up as k8s.volume.* metrics.
 #
-# The PV path is created on the node by lgtm.sh before this manifest is
-# applied. Node affinity is pinned to the single k3d server node.
+# The PV path is a tmpfs mount created on the node by lgtm.sh before this
+# manifest is applied (see lgtm.sh for why tmpfs and not a plain directory).
+# Node affinity is pinned to the single k3d server node.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/scripts/pv-workload.yaml
+++ b/scripts/pv-workload.yaml
@@ -1,0 +1,94 @@
+# A PVC-backed workload so the Persistent Volumes dashboard has data.
+#
+# Uses a static `local` PersistentVolume instead of the k3d default
+# `local-path` StorageClass: local-path provisions hostPath volumes, for
+# which the kubelet reports no filesystem stats (the hostPath volume plugin
+# has no metrics provider). `local` volumes report stats via statfs, which
+# the kubeletstats receiver picks up as k8s.volume.* metrics.
+#
+# The PV path is created on the node by lgtm.sh before this manifest is
+# applied. Node affinity is pinned to the single k3d server node.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-static
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-writer
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-static
+  local:
+    path: /var/lib/kubernetes-mixin-otel/pv-writer
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - k3d-kubernetes-mixin-otel-server-0
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pv-writer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-static
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pv-writer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pv-writer
+  template:
+    metadata:
+      labels:
+        app: pv-writer
+    spec:
+      containers:
+        - name: writer
+          image: busybox:1.36
+          # Cycle through 20 x 5MiB files so volume space and inode usage
+          # stay non-zero and visibly change over time on the dashboard.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              i=0
+              while true; do
+                dd if=/dev/urandom of=/data/file-$((i % 20)).bin bs=1M count=5 2>/dev/null
+                i=$((i + 1))
+                sleep 30
+              done
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pv-writer

--- a/tests/persistentvolumesusage_queries_test.libsonnet
+++ b/tests/persistentvolumesusage_queries_test.libsonnet
@@ -1,0 +1,38 @@
+local pv = import '../dashboards/queries/persistentvolumesusage.libsonnet';
+
+local config = {
+  _config: {},
+};
+
+local expectedSpaceUsed =
+  'max(k8s_volume_capacity_bytes{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace", k8s_persistentvolumeclaim_name="$volume"}) - max(k8s_volume_available_bytes{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace", k8s_persistentvolumeclaim_name="$volume"})';
+
+local expectedInodesPercent =
+  'max(k8s_volume_inodes_used_ratio{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace", k8s_persistentvolumeclaim_name="$volume"}) / max(k8s_volume_inodes_ratio{k8s_cluster_name="$cluster", k8s_namespace_name="$namespace", k8s_persistentvolumeclaim_name="$volume"}) * 100';
+
+{
+  testVolumeSpaceUsageUsed:
+    local result = pv.volumeSpaceUsageUsed(config);
+    assert result == expectedSpaceUsed :
+           'volumeSpaceUsageUsed failed.\nExpected:\n%s\n\nGot:\n%s' % [expectedSpaceUsed, result];
+    'PASS: volumeSpaceUsageUsed',
+
+  testVolumeInodesUsagePercent:
+    local result = pv.volumeInodesUsagePercent(config);
+    assert result == expectedInodesPercent :
+           'volumeInodesUsagePercent failed.\nExpected:\n%s\n\nGot:\n%s' % [expectedInodesPercent, result];
+    'PASS: volumeInodesUsagePercent',
+
+  testAllQueriesImplemented:
+    local queries = [
+      pv.volumeSpaceUsageUsed(config),
+      pv.volumeSpaceUsageFree(config),
+      pv.volumeSpaceUsagePercent(config),
+      pv.volumeInodesUsageUsed(config),
+      pv.volumeInodesUsageFree(config),
+      pv.volumeInodesUsagePercent(config),
+    ];
+    assert std.all([q != null && q != '' && q != '0' for q in queries]) :
+           'Some persistent volume queries are not implemented';
+    'PASS: all 6 persistent volume queries implemented',
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on #96 (kubernetes-mixin bump) — review/merge that first. Part of #95.

## Summary

- Ports the kubernetes-mixin **Persistent Volumes** dashboard to OTel-native metrics using the upstream `$._queries.persistentVolume` / `$._variables.persistentVolume` override hooks (from kubernetes-monitoring/kubernetes-mixin#1252), reusing the vendored template for all panels and layout.
- Queries use the kubeletstats `volume` metric group only — no Prometheus exporter scrape:
  - `k8s_volume_capacity_bytes`, `k8s_volume_available_bytes`
  - `k8s_volume_inodes_ratio`, `k8s_volume_inodes_used_ratio` — the `_ratio` suffix comes from the Prometheus OTLP translation of dimensionless (unit `1`) gauges; they are absolute inode counts (documented in `docs/otel-mapping.md`).
- Variables are single-select (cluster/namespace/PVC), mirroring the upstream dashboard: the space/inodes gauges compute ratios for one PVC at a time. Variable queries filter `k8s_persistentvolumeclaim_name!=""` to exclude configMap/secret/emptyDir volumes that the `volume` metric group also reports.
- Adds jsonnet query tests (`tests/persistentvolumesusage_queries_test.libsonnet`), wired into `make test`.

## Dev environment (visual testing)

- **Collector (DaemonSet values):**
  - Enable the kubeletstats `volume` metric group (not collected by default) and `extra_metadata_labels: [k8s.volume.type]`, which adds the `k8s.persistentvolumeclaim.name` resource attribute from the pod's pvcRef.
  - Add `nodes/proxy` RBAC (the kubelet `/pods` endpoint used by `extra_metadata_labels` authorizes as `get nodes/proxy`).
  - New `transform/copy_volume_attributes` processor copies volume resource attributes to datapoint attributes, following the existing `copy_node_name` workaround for attributes the Prometheus OTLP endpoint does not promote.
- **PVC-backed workload (`scripts/pv-workload.yaml`):** a busybox Deployment cycling 20×5MiB files on a 1Gi PVC, so space/inode usage is non-zero and visibly changes.
  - Uses a **static `local` PersistentVolume** rather than the k3d default `local-path` StorageClass: local-path provisions hostPath volumes, whose volume plugin has no metrics provider, so the kubelet reports no filesystem stats for them. `local` volumes report stats via statfs and show up as `k8s.volume.*` metrics.
  - `lgtm.sh` creates the PV backing directory on the k3d node before applying the manifest.
- Known caveat: statfs on a `local` PV reflects the underlying node filesystem, so reported capacity is the node disk size rather than the 1Gi claim size. Fine for visual verification.

## Test plan

- [x] `make generate` renders `dashboards_out/persistentvolumesusage.json` with OTel queries/variables
- [x] `make lint` (jsonnet-lint + dashboard-linter --strict) passes
- [x] `make test` passes (new PV query tests included)
- [x] `helm template` renders merged kubeletstats config (`volume` group, extra_metadata_labels), `nodes/proxy` ClusterRole rule, and the volume transform in the pipeline
- [x] `make dev` + `make dev-port-forward`, then visually verify the Persistent Volumes dashboard shows the `pv-writer` PVC with changing space/inode usage

Made with [Cursor](https://cursor.com)