### PR TITLE
queries: build PromQL on the tsqtsq jsonnet library

### DIFF
--- a/dashboards/resources/queries/cluster.libsonnet
+++ b/dashboards/resources/queries/cluster.libsonnet
@@ -1,4 +1,17 @@
 // queries path must match the path in the kubernetes-mixin template
+local tsqtsq = import 'github.com/grafana/tsqtsq/jsonnet/promql.libsonnet';
+
+local promql = tsqtsq.promql;
+
+local selector(metric, values) =
+  tsqtsq.Expression({
+    metric: metric,
+    values: values,
+    defaultOperator: tsqtsq.MatchingOperator.regexMatch,
+  }).toString();
+
+local clusterBy = ['k8s_cluster_name', 'k8s_namespace_name'];
+
 {
   // CPU stat queries
   cpuUtilisation(config):: '0',
@@ -6,15 +19,15 @@
   cpuLimitsCommitment(config):: '0',
 
   // CPU usage and namespace queries
-  cpuUsageByNamespace(config):: |||
-    sum(
-      sum by (k8s_cluster_name, k8s_namespace_name) (
-        rate(
-          k8s_pod_cpu_time_seconds_total{k8s_cluster_name=~"${cluster}"}[$__rate_interval]
-        )
-      )
-    )
-  |||,
+  cpuUsageByNamespace(config)::
+    promql.sum({
+      expr: promql.sum({
+        by: clusterBy,
+        expr: promql.rate({
+          expr: selector('k8s_pod_cpu_time_seconds_total', { k8s_cluster_name: '${cluster}' }),
+        }),
+      }),
+    }),
 
   podsByNamespace(config):: '0',
   workloadsByNamespace(config):: '0',
@@ -29,11 +42,11 @@
   memoryLimitsCommitment(config):: '0',
 
   // Memory usage and namespace queries
-  memoryUsageByNamespace(config):: |||
-    sum by (k8s_cluster_name, k8s_namespace_name) (
-      k8s_container_memory_request_bytes{k8s_cluster_name=~"${cluster:pipe}"}
-    )
-  |||,
+  memoryUsageByNamespace(config)::
+    promql.sum({
+      by: clusterBy,
+      expr: selector('k8s_container_memory_request_bytes', { k8s_cluster_name: '${cluster:pipe}' }),
+    }),
 
   memoryRequestsByNamespace(config):: '0',
   memoryUsageVsRequests(config):: '0',

--- a/dashboards/resources/queries/common.libsonnet
+++ b/dashboards/resources/queries/common.libsonnet
@@ -1,115 +1,137 @@
-// Shared query builders for all resource dashboards
-local maxBy = 'k8s_cluster_name, k8s_namespace_name, k8s_pod_name, k8s_container_name';
-local podMaxBy = 'k8s_cluster_name, k8s_namespace_name, k8s_pod_name';
+// Shared query builders for all resource dashboards, built on the tsqtsq
+// jsonnet library (the same PromQL query API as the TypeScript tsqtsq).
+//
+// The helpers here encode this mixin's conventions -- OTel semantic
+// convention labels, and de-duplication of series via max by the container
+// identity labels -- expressed through the shared tsqtsq primitives.
+local tsqtsq = import 'github.com/grafana/tsqtsq/jsonnet/promql.libsonnet';
 
-local withRate(expr, filters, useRate) =
-  if useRate then
-    'rate(%s{%s}[$__rate_interval])' % [expr, filters]
-  else
-    '%s{%s}' % [expr, filters];
+local promql = tsqtsq.promql;
 
-local sumExpr(inner, by) =
-  if by == '' then
-    'sum(%s)' % inner
-  else
-    'sum by (%s) (%s)' % [by, inner];
+local maxBy = ['k8s_cluster_name', 'k8s_namespace_name', 'k8s_pod_name', 'k8s_container_name'];
+local podMaxBy = ['k8s_cluster_name', 'k8s_namespace_name', 'k8s_pod_name'];
 
-local avgExpr(inner, by) =
-  if by == '' then
-    'avg(%s)' % inner
-  else
-    'avg by (%s) (%s)' % [by, inner];
+// Metric selector: dashboard variable filters (regex-matched values) plus
+// optional extra selectors (e.g. direction="receive").
+local selector(metric, values, selectors=[]) =
+  tsqtsq.Expression({
+    metric: metric,
+    values: values,
+    defaultOperator: tsqtsq.MatchingOperator.regexMatch,
+    defaultSelectors: selectors,
+  }).toString();
 
-local maxExpr(inner, by) =
-  'max by (%s) (%s)' % [by, inner];
+local maybeRate(expr, useRate) =
+  if useRate then promql.rate({ expr: expr }) else expr;
+
+local clampMax(expr) =
+  // TODO(tsqtsq): replace with promql.clamp_max once available upstream.
+  'clamp_max(%s, 1)' % expr;
 
 // Active pod filter (Pending=1 or Running=2), normalized to 1
 // pod phases are 1=Pending, 2=Running, 3=Succeeded, 4=Failed, 5=Unknown
 // known issue here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36819
-local activePodFilter(phaseFilters) =
-  |||
-    * on (%(podMaxBy)s)
-    group_left() clamp_max(
-      max by (%(podMaxBy)s) (
-        (k8s_pod_phase{%(filters)s} == 1) or (k8s_pod_phase{%(filters)s} == 2)
-      ), 1
-    )
-  ||| % { podMaxBy: podMaxBy, filters: phaseFilters };
+local phaseActive(phaseValues) =
+  local phaseSelector = selector('k8s_pod_phase', phaseValues);
+  clampMax(promql.max({
+    by: podMaxBy,
+    expr: promql.or({
+      left: '(%s)' % promql.eq({ left: phaseSelector, right: '1' }),
+      right: '(%s)' % promql.eq({ left: phaseSelector, right: '2' }),
+    }),
+  }));
+
+// Joins expr against the active-pod filter: expr * on (...) group_left() ...
+local activeOnly(expr, phaseValues) =
+  promql.mul({
+    left: expr,
+    right: phaseActive(phaseValues),
+    on: podMaxBy,
+    groupLeft: [],
+  });
 
 {
-  metricSum(metric, filters, by='')::
-    sumExpr(
-      maxExpr('%s{%s}' % [metric, filters], maxBy),
-      by
-    ),
+  metricSum(metric, values, by=null, selectors=[])::
+    promql.sum({
+      by: by,
+      expr: promql.max({ by: maxBy, expr: selector(metric, values, selectors) }),
+    }),
 
-  rateSum(metric, filters, by='')::
-    sumExpr(
-      maxExpr(withRate(metric, filters, true), maxBy),
-      by
-    ),
+  rateSum(metric, values, by=null, selectors=[])::
+    promql.sum({
+      by: by,
+      expr: promql.max({ by: maxBy, expr: promql.rate({ expr: selector(metric, values, selectors) }) }),
+    }),
 
-  rateSumPodLevel(metric, filters, by='')::
-    sumExpr(
-      maxExpr(withRate(metric, filters, true), podMaxBy),
-      by
-    ),
+  rateSumPodLevel(metric, values, by=null, selectors=[])::
+    promql.sum({
+      by: by,
+      expr: promql.max({ by: podMaxBy, expr: promql.rate({ expr: selector(metric, values, selectors) }) }),
+    }),
 
-  rateAvg(metric, filters, by='')::
-    avgExpr(
-      maxExpr(withRate(metric, filters, true), maxBy),
-      by
-    ),
+  rateAvg(metric, values, by=null, selectors=[])::
+    promql.avg({
+      by: by,
+      expr: promql.max({ by: maxBy, expr: promql.rate({ expr: selector(metric, values, selectors) }) }),
+    }),
 
-  ratioSum(numeratorMetric, denominatorMetric, filters, by='', useRate=false)::
-    sumExpr(
-      '%s / %s' % [
-        maxExpr(withRate(numeratorMetric, filters, useRate), maxBy),
-        maxExpr('%s{%s}' % [denominatorMetric, filters], maxBy),
-      ],
-      by
-    ),
+  ratioSum(numeratorMetric, denominatorMetric, values, by=null, useRate=false)::
+    promql.sum({
+      by: by,
+      expr: promql.div({
+        left: promql.max({ by: maxBy, expr: maybeRate(selector(numeratorMetric, values), useRate) }),
+        right: promql.max({ by: maxBy, expr: selector(denominatorMetric, values) }),
+      }),
+    }),
 
-  ratioSumPodLevel(numeratorMetric, denominatorMetric, filters, by='', useRate=false)::
-    sumExpr(
-      '%s / %s' % [
-        maxExpr(withRate(numeratorMetric, filters, useRate), podMaxBy),
-        sumExpr(maxExpr('%s{%s}' % [denominatorMetric, filters], maxBy), podMaxBy),
-      ],
-      by
-    ),
+  ratioSumPodLevel(numeratorMetric, denominatorMetric, values, by=null, useRate=false)::
+    promql.sum({
+      by: by,
+      expr: promql.div({
+        left: promql.max({ by: podMaxBy, expr: maybeRate(selector(numeratorMetric, values), useRate) }),
+        right: promql.sum({
+          by: podMaxBy,
+          expr: promql.max({ by: maxBy, expr: selector(denominatorMetric, values) }),
+        }),
+      }),
+    }),
 
-  differenceSum(metric1, metric2, filters, by='')::
-    sumExpr(
-      '%s - %s' % [
-        maxExpr('%s{%s}' % [metric1, filters], maxBy),
-        maxExpr('%s{%s}' % [metric2, filters], maxBy),
-      ],
-      by
-    ),
+  differenceSum(metric1, metric2, values, by=null)::
+    promql.sum({
+      by: by,
+      expr: promql.sub({
+        left: promql.max({ by: maxBy, expr: selector(metric1, values) }),
+        right: promql.max({ by: maxBy, expr: selector(metric2, values) }),
+      }),
+    }),
 
-  metricSumActiveOnly(metric, filters, phaseFilters, by='')::
-    sumExpr(
-      maxExpr('%s{%s}%s' % [metric, filters, activePodFilter(phaseFilters)], maxBy),
-      by
-    ),
+  metricSumActiveOnly(metric, values, phaseValues, by=null)::
+    promql.sum({
+      by: by,
+      expr: promql.max({ by: maxBy, expr: activeOnly(selector(metric, values), phaseValues) }),
+    }),
 
-  ratioSumActiveOnly(numeratorMetric, denominatorMetric, filters, phaseFilters, by='', useRate=false)::
-    sumExpr(
-      '%s / %s' % [
-        maxExpr(withRate(numeratorMetric, filters, useRate), maxBy),
-        maxExpr('%s{%s}%s' % [denominatorMetric, filters, activePodFilter(phaseFilters)], maxBy),
-      ],
-      by
-    ),
+  ratioSumActiveOnly(numeratorMetric, denominatorMetric, values, phaseValues, by=null, useRate=false)::
+    promql.sum({
+      by: by,
+      expr: promql.div({
+        left: promql.max({ by: maxBy, expr: maybeRate(selector(numeratorMetric, values), useRate) }),
+        right: promql.max({ by: maxBy, expr: activeOnly(selector(denominatorMetric, values), phaseValues) }),
+      }),
+    }),
 
-  ratioSumActiveOnlyPodLevel(numeratorMetric, denominatorMetric, filters, phaseFilters, by='', useRate=false)::
-    sumExpr(
-      '%s / (%s%s)' % [
-        maxExpr(withRate(numeratorMetric, filters, useRate), podMaxBy),
-        sumExpr(maxExpr('%s{%s}' % [denominatorMetric, filters], maxBy), podMaxBy),
-        activePodFilter(phaseFilters),
-      ],
-      by
-    ),
+  ratioSumActiveOnlyPodLevel(numeratorMetric, denominatorMetric, values, phaseValues, by=null, useRate=false)::
+    promql.sum({
+      by: by,
+      expr: promql.div({
+        left: promql.max({ by: podMaxBy, expr: maybeRate(selector(numeratorMetric, values), useRate) }),
+        right: '(%s)' % activeOnly(
+          promql.sum({
+            by: podMaxBy,
+            expr: promql.max({ by: maxBy, expr: selector(denominatorMetric, values) }),
+          }),
+          phaseValues,
+        ),
+      }),
+    }),
 }

--- a/dashboards/resources/queries/namespace.libsonnet
+++ b/dashboards/resources/queries/namespace.libsonnet
@@ -1,25 +1,34 @@
 // queries path must match the path in the kubernetes-mixin template
 local b = import './common.libsonnet';
+local tsqtsq = import 'github.com/grafana/tsqtsq/jsonnet/promql.libsonnet';
+
+// Dashboard variable filters, applied as regex matchers to every query.
+local values = {
+  k8s_cluster_name: '${cluster:pipe}',
+  k8s_namespace_name: '${namespace:pipe}',
+};
+
+local direction(value) = [
+  { label: 'direction', operator: tsqtsq.MatchingOperator.equal, value: value },
+];
 
 {
-  local filters = 'k8s_cluster_name=~"${cluster:pipe}", k8s_namespace_name=~"${namespace:pipe}"',
-
   // CPU Utilization Stat Queries
   cpuUtilisationFromRequests(config)::
-    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_request', filters, useRate=true),
+    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_request', values, useRate=true),
 
   cpuUtilisationFromLimits(config)::
-    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_limit', filters, useRate=true),
+    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_limit', values, useRate=true),
 
   memoryUtilisationFromRequests(config)::
-    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_request_bytes', filters),
+    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_request_bytes', values),
 
   memoryUtilisationFromLimits(config)::
-    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_limit_bytes', filters),
+    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_limit_bytes', values),
 
   // CPU Usage TimeSeries Queries
   cpuUsageByPod(config)::
-    b.rateSumPodLevel('k8s_pod_cpu_time_seconds_total', filters, by='k8s_pod_name'),
+    b.rateSumPodLevel('k8s_pod_cpu_time_seconds_total', values, by=['k8s_pod_name']),
 
   cpuQuotaRequests(config)::
     '0',
@@ -30,20 +39,20 @@ local b = import './common.libsonnet';
   // CPU Quota Table Queries
   // first query reuses cpuUsageByPod query
   cpuRequestsByPod(config)::
-    b.metricSumActiveOnly('k8s_container_cpu_request', filters, filters, by='k8s_pod_name'),
+    b.metricSumActiveOnly('k8s_container_cpu_request', values, values, by=['k8s_pod_name']),
 
   cpuUsageVsRequests(config)::
-    b.ratioSumActiveOnlyPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_request', filters, filters, by='k8s_pod_name', useRate=true),
+    b.ratioSumActiveOnlyPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_request', values, values, by=['k8s_pod_name'], useRate=true),
 
   cpuLimitsByPod(config)::
-    b.metricSumActiveOnly('k8s_container_cpu_limit', filters, filters, by='k8s_pod_name'),
+    b.metricSumActiveOnly('k8s_container_cpu_limit', values, values, by=['k8s_pod_name']),
 
   cpuUsageVsLimits(config)::
-    b.ratioSumActiveOnlyPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_limit', filters, filters, by='k8s_pod_name', useRate=true),
+    b.ratioSumActiveOnlyPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_limit', values, values, by=['k8s_pod_name'], useRate=true),
 
   // Memory Usage TimeSeries Queries
   memoryUsageByPod(config)::
-    b.metricSum('k8s_pod_memory_working_set_bytes', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_pod_memory_working_set_bytes', values, by=['k8s_pod_name']),
 
   memoryQuotaRequests(config)::
     '0',
@@ -53,19 +62,19 @@ local b = import './common.libsonnet';
 
   // Memory Quota Table Queries
   memoryRequestsByPod(config)::
-    b.metricSumActiveOnly('k8s_container_memory_request_bytes', filters, filters, by='k8s_pod_name'),
+    b.metricSumActiveOnly('k8s_container_memory_request_bytes', values, values, by=['k8s_pod_name']),
 
   memoryUsageVsRequests(config)::
-    b.ratioSumActiveOnlyPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_request_bytes', filters, filters, by='k8s_pod_name'),
+    b.ratioSumActiveOnlyPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_request_bytes', values, values, by=['k8s_pod_name']),
 
   memoryLimitsByPod(config)::
-    b.metricSumActiveOnly('k8s_container_memory_limit_bytes', filters, filters, by='k8s_pod_name'),
+    b.metricSumActiveOnly('k8s_container_memory_limit_bytes', values, values, by=['k8s_pod_name']),
 
   memoryUsageVsLimits(config)::
-    b.ratioSumActiveOnlyPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_limit_bytes', filters, filters, by='k8s_pod_name'),
+    b.ratioSumActiveOnlyPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_limit_bytes', values, values, by=['k8s_pod_name']),
 
   memoryUsageRSS(config)::
-    b.metricSum('k8s_pod_memory_rss_bytes', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_pod_memory_rss_bytes', values, by=['k8s_pod_name']),
 
   memoryUsageCache(config)::
     '0',
@@ -75,10 +84,10 @@ local b = import './common.libsonnet';
 
   // Network Table Queries
   networkReceiveBandwidth(config)::
-    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', filters + ', direction="receive"', by='k8s_namespace_name'),
+    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', values, by=['k8s_namespace_name'], selectors=direction('receive')),
 
   networkTransmitBandwidth(config)::
-    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', filters + ', direction="transmit"', by='k8s_namespace_name'),
+    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', values, by=['k8s_namespace_name'], selectors=direction('transmit')),
 
   networkReceivePackets(config)::
     '0',
@@ -87,17 +96,17 @@ local b = import './common.libsonnet';
     '0',
 
   networkReceivePacketsDropped(config)::
-    b.rateSumPodLevel('k8s_pod_network_errors_total', filters + ', direction="receive"', by='k8s_namespace_name'),
+    b.rateSumPodLevel('k8s_pod_network_errors_total', values, by=['k8s_namespace_name'], selectors=direction('receive')),
 
   networkTransmitPacketsDropped(config)::
-    b.rateSumPodLevel('k8s_pod_network_errors_total', filters + ', direction="transmit"', by='k8s_namespace_name'),
+    b.rateSumPodLevel('k8s_pod_network_errors_total', values, by=['k8s_namespace_name'], selectors=direction('transmit')),
 
   // Network TimeSeries Queries
   networkReceiveBandwidthTimeSeries(config)::
-    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', filters + ', direction="receive"', by='k8s_namespace_name'),
+    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', values, by=['k8s_namespace_name'], selectors=direction('receive')),
 
   networkTransmitBandwidthTimeSeries(config)::
-    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', filters + ', direction="transmit"', by='k8s_namespace_name'),
+    b.rateSumPodLevel('k8s_pod_network_io_bytes_total', values, by=['k8s_namespace_name'], selectors=direction('transmit')),
 
   // Storage TimeSeries Queries
   iopsReadsWrites(config)::

--- a/dashboards/resources/queries/pod.libsonnet
+++ b/dashboards/resources/queries/pod.libsonnet
@@ -1,73 +1,83 @@
 // queries path must match the path in the kubernetes-mixin template
 local b = import './common.libsonnet';
+local tsqtsq = import 'github.com/grafana/tsqtsq/jsonnet/promql.libsonnet';
+
+// Dashboard variable filters, applied as regex matchers to every query.
+local values = {
+  k8s_cluster_name: '${cluster:pipe}',
+  k8s_namespace_name: '${namespace:pipe}',
+  k8s_pod_name: '${pod:pipe}',
+};
+
+local direction(value) = [
+  { label: 'direction', operator: tsqtsq.MatchingOperator.equal, value: value },
+];
 
 {
-  local filters = 'k8s_cluster_name=~"${cluster:pipe}", k8s_namespace_name=~"${namespace:pipe}", k8s_pod_name=~"${pod:pipe}"',
-
   // CPU Queries
   cpuUsageByContainer(config)::
-    b.rateSum('k8s_pod_cpu_time_seconds_total', filters, by='k8s_container_name'),
+    b.rateSum('k8s_pod_cpu_time_seconds_total', values, by=['k8s_container_name']),
 
   cpuRequests(config)::
-    b.metricSum('k8s_container_cpu_request', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_container_cpu_request', values, by=['k8s_pod_name']),
 
   cpuLimits(config)::
-    b.metricSum('k8s_container_cpu_limit', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_container_cpu_limit', values, by=['k8s_pod_name']),
 
   cpuThrottling(config)::
     '0',
 
   // CPU Quota Table Queries
   cpuRequestsByContainer(config)::
-    b.metricSum('k8s_container_cpu_request', filters, by='k8s_container_name'),
+    b.metricSum('k8s_container_cpu_request', values, by=['k8s_container_name']),
 
   cpuUsageVsRequests(config)::
-    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_request', filters, by='k8s_pod_name', useRate=true),
+    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_request', values, by=['k8s_pod_name'], useRate=true),
 
   cpuLimitsByContainer(config)::
-    b.metricSum('k8s_container_cpu_limit', filters, by='k8s_container_name'),
+    b.metricSum('k8s_container_cpu_limit', values, by=['k8s_container_name']),
 
   cpuUsageVsLimits(config)::
-    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_limit', filters, by='k8s_pod_name', useRate=true),
+    b.ratioSumPodLevel('k8s_pod_cpu_time_seconds_total', 'k8s_container_cpu_limit', values, by=['k8s_pod_name'], useRate=true),
 
   // Memory Queries
   memoryUsageWSS(config)::
-    b.metricSum('k8s_pod_memory_working_set_bytes', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_pod_memory_working_set_bytes', values, by=['k8s_pod_name']),
 
   memoryRequests(config)::
-    b.metricSum('k8s_container_memory_request_bytes', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_container_memory_request_bytes', values, by=['k8s_pod_name']),
 
   memoryLimits(config)::
-    b.metricSum('k8s_container_memory_limit_bytes', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_container_memory_limit_bytes', values, by=['k8s_pod_name']),
 
   // Memory Quota Table Queries
   memoryRequestsByContainer(config)::
-    b.metricSum('k8s_container_memory_request_bytes', filters, by='k8s_container_name'),
+    b.metricSum('k8s_container_memory_request_bytes', values, by=['k8s_container_name']),
 
   memoryUsageVsRequests(config)::
-    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_request_bytes', filters, by='k8s_pod_name'),
+    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_request_bytes', values, by=['k8s_pod_name']),
 
   memoryLimitsByContainer(config)::
-    b.metricSum('k8s_container_memory_limit_bytes', filters, by='k8s_container_name'),
+    b.metricSum('k8s_container_memory_limit_bytes', values, by=['k8s_container_name']),
 
   memoryUsageVsLimits(config)::
-    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_limit_bytes', filters, by='k8s_pod_name'),
+    b.ratioSumPodLevel('k8s_pod_memory_working_set_bytes', 'k8s_container_memory_limit_bytes', values, by=['k8s_pod_name']),
 
   memoryUsageRSS(config)::
-    b.metricSum('k8s_pod_memory_rss_bytes', filters, by='k8s_pod_name'),
+    b.metricSum('k8s_pod_memory_rss_bytes', values, by=['k8s_pod_name']),
 
   memoryUsageCache(config)::
-    b.differenceSum('k8s_pod_memory_usage_bytes', 'k8s_pod_memory_rss_bytes', filters, by='k8s_pod_name'),
+    b.differenceSum('k8s_pod_memory_usage_bytes', 'k8s_pod_memory_rss_bytes', values, by=['k8s_pod_name']),
 
   memoryUsageSwap(config)::
     '0',
 
   // Network Queries
   networkReceiveBandwidth(config)::
-    b.rateSum('k8s_pod_network_io_bytes_total', filters + ', direction="receive"', by='k8s_pod_name'),
+    b.rateSum('k8s_pod_network_io_bytes_total', values, by=['k8s_pod_name'], selectors=direction('receive')),
 
   networkTransmitBandwidth(config)::
-    b.rateSum('k8s_pod_network_io_bytes_total', filters + ', direction="transmit"', by='k8s_pod_name'),
+    b.rateSum('k8s_pod_network_io_bytes_total', values, by=['k8s_pod_name'], selectors=direction('transmit')),
 
   networkReceivePackets(config)::
     '0',
@@ -76,10 +86,10 @@ local b = import './common.libsonnet';
     '0',
 
   networkReceivePacketsDropped(config)::
-    b.rateSum('k8s_pod_network_errors_total', filters + ', direction="receive"', by='k8s_pod_name'),
+    b.rateSum('k8s_pod_network_errors_total', values, by=['k8s_pod_name'], selectors=direction('receive')),
 
   networkTransmitPacketsDropped(config)::
-    b.rateSum('k8s_pod_network_errors_total', filters + ', direction="transmit"', by='k8s_pod_name'),
+    b.rateSum('k8s_pod_network_errors_total', values, by=['k8s_pod_name'], selectors=direction('transmit')),
 
   // Storage Queries - Pod Level
   iopsPodReads(config)::

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "cursor/jsonnet-library-4994"
+      "version": "b6240b86ed496db94d4a3f203224000a3bed1239"
     },
     {
       "source": {

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -4,6 +4,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/tsqtsq.git",
+          "subdir": "jsonnet"
+        }
+      },
+      "version": "cursor/jsonnet-library-4994"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git"
         }
       },

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -28,7 +28,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "711e778a2b4fa8a4e2a4cbe61dc8188748fe1ec8",
+      "version": "b6240b86ed496db94d4a3f203224000a3bed1239",
       "sum": "7ixhNUIY0E76CdIzqy77vGzh4LJ056Ufr0+guAPqE6U="
     },
     {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -24,6 +24,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/tsqtsq.git",
+          "subdir": "jsonnet"
+        }
+      },
+      "version": "711e778a2b4fa8a4e2a4cbe61dc8188748fe1ec8",
+      "sum": "7ixhNUIY0E76CdIzqy77vGzh4LJ056Ufr0+guAPqE6U="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/jsonnet-libs/docsonnet.git",
           "subdir": "doc-util"
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replaces the hand-rolled string-template query builders in `dashboards/resources/queries/common.libsonnet` with the **tsqtsq jsonnet library** (added upstream in grafana/tsqtsq#130), imported via `jb` and pinned to tsqtsq `main`:

```json
{
  "source": { "git": { "remote": "https://github.com/grafana/tsqtsq.git", "subdir": "jsonnet" } },
  "version": "b6240b86ed496db94d4a3f203224000a3bed1239"
}
```

```jsonnet
local tsqtsq = import 'github.com/grafana/tsqtsq/jsonnet/promql.libsonnet';
```

tsqtsq now provides the generic PromQL API (aggregations, `rate`, binary ops with vector matching, `Expression` selectors). This mixin keeps only its domain conventions as thin local helpers on top: OTel semconv labels, max-by-container-identity dedup, and the active-pod filter (`clamp_max` is a local one-liner until tsqtsq grows `promql.clamp_max`).

The jsonnet API mirrors tsqtsq's TypeScript API one-to-one, so the same query-building idioms apply in this mixin and in TypeScript codebases, and behaviour is pinned upstream by a conformance corpus generated from tsqtsq's jest suite.

Example from `queries/common.libsonnet` — the familiar tsqtsq API, straight out of the TypeScript docs:

```jsonnet
local promql = tsqtsq.promql;

// k8s_pod_cpu_time_seconds_total{k8s_cluster_name=~"${cluster:pipe}", ...}
local selector(metric, values, selectors=[]) =
  tsqtsq.Expression({
    metric: metric,
    values: values,
    defaultOperator: tsqtsq.MatchingOperator.regexMatch,
    defaultSelectors: selectors,
  }).toString();

// sum by (...) (max by (...) (rate(metric{...}[$__rate_interval])))
rateSum(metric, values, by=null, selectors=[])::
  promql.sum({
    by: by,
    expr: promql.max({ by: maxBy, expr: promql.rate({ expr: selector(metric, values, selectors) }) }),
  }),

// expr * on (...) group_left() clamp_max(max by (...) ((phase == 1) or (phase == 2)), 1)
local activeOnly(expr, phaseValues) =
  promql.mul({
    left: expr,
    right: clampMax(promql.max({
      by: podMaxBy,
      expr: promql.or({
        left: '(%s)' % promql.eq({ left: selector('k8s_pod_phase', phaseValues), right: '1' }),
        right: '(%s)' % promql.eq({ left: selector('k8s_pod_phase', phaseValues), right: '2' }),
      }),
    })),
    on: podMaxBy,
    groupLeft: [],
  });
```

## Verification

- `make test`: all byte-asserted query tests pass **unchanged** — output is byte-identical for every asserted query.
- `make lint` (jsonnet-lint + dashboard-linter --strict): clean.
- `make generate` diff vs `main` is formatting-only, in three expected categories:
  1. hand-formatted multiline queries render single-line (cluster dashboard);
  2. active-pod-filter joins render single-line instead of the old multiline `|||` template;
  3. the `direction="..."` matcher moves to the front of the selector (`Expression` emits default selectors before variable filters).

## Follow-ups

- Move the pin to a version tag once tsqtsq cuts a release containing the jsonnet library.
- Replace the local `clampMax` helper with `promql.clamp_max` if/when tsqtsq adds it.
- Relicensing to Apache-2.0 is proposed separately in grafana/tsqtsq#131.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f48af-0015-782e-8c49-578c8da24994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f48af-0015-782e-8c49-578c8da24994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

